### PR TITLE
Add plur-hermes — persistent learning plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-plugin-chrome-profiles](https://github.com/anpicasso/hermes-plugin-chrome-profiles) by [anpicasso](https://github.com/anpicasso) - Switch browser tools between Chrome profiles via CDP. Useful for multi-account testing or browsing with different saved sessions.
 - **[experimental]** [hermes-cloudflare](https://github.com/raulvidis/hermes-cloudflare) by [raulvidis](https://github.com/raulvidis) - Cloudflare browser rendering plugin. Headless browsing through Cloudflare's infrastructure instead of local browser automation.
 - **[beta]** [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) by [42-evey](https://github.com/42-evey) - Claude Code plugin for bridging with Evey (hermes-agent). Lets Claude Code and Hermes share context and hand off tasks between each other.
+- **[beta]** [plur-hermes](https://github.com/plur-ai/plur) by [plur-ai](https://github.com/plur-ai) - Persistent learning for Hermes agents. Open engram format (YAML), shared across tools, meta-engrams for transfer of knowledge. `pip install plur-hermes`
 
 ### Skill Registries & Discovery
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-plugin-chrome-profiles](https://github.com/anpicasso/hermes-plugin-chrome-profiles) by [anpicasso](https://github.com/anpicasso) - Switch browser tools between Chrome profiles via CDP. Useful for multi-account testing or browsing with different saved sessions.
 - **[experimental]** [hermes-cloudflare](https://github.com/raulvidis/hermes-cloudflare) by [raulvidis](https://github.com/raulvidis) - Cloudflare browser rendering plugin. Headless browsing through Cloudflare's infrastructure instead of local browser automation.
 - **[beta]** [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) by [42-evey](https://github.com/42-evey) - Claude Code plugin for bridging with Evey (hermes-agent). Lets Claude Code and Hermes share context and hand off tasks between each other.
-- **[beta]** [plur-hermes](https://github.com/plur-ai/plur) by [plur-ai](https://github.com/plur-ai) - Persistent learning for Hermes agents. Open engram format (YAML), shared across tools, meta-engrams for transfer of knowledge. `pip install plur-hermes`
+- **[beta]** [plur-hermes](https://github.com/plur-ai/plur) by [plur-ai](https://github.com/plur-ai) - Persistent learning for Hermes agents. Open engram format (YAML), shared across tools, with meta-engrams for knowledge transfer.
 
 ### Skill Registries & Discovery
 


### PR DESCRIPTION
Adds plur-hermes — persistent learning plugin for Hermes agents.

- Apache-2.0, fully open source
- Local-first: plain YAML, zero API calls
- GitHub: https://github.com/plur-ai/plur
- Website: plur.ai

Resolves #11