### PR TITLE
feat: add Hindsight long-term memory integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) - Solana blockchain intelligence MCP server. Provides on-chain analytics and wallet data to Hermes via MCP.
 - **[experimental]** [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) - Adversarial multi-perspective council MCP server. Multiple AI viewpoints debate before the agent commits to a decision.
 - **[experimental]** [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) - NVIDIA capability registry and Spark-aware routing layer. Routes compute-heavy tasks to available GPU infrastructure.
+- **[beta]** [hindsight-hermes](https://hindsight.vectorize.io/sdks/integrations/hermes) by [Vectorize](https://vectorize.io) - Long-term memory integration that replaces Hermes's built-in memory with three specialized tools: retain (store), recall (search), and reflect (reason over memories). Gives agents persistent memory across sessions via Hindsight memory banks.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) - Solana blockchain intelligence MCP server. Provides on-chain analytics and wallet data to Hermes via MCP.
 - **[experimental]** [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) - Adversarial multi-perspective council MCP server. Multiple AI viewpoints debate before the agent commits to a decision.
 - **[experimental]** [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) - NVIDIA capability registry and Spark-aware routing layer. Routes compute-heavy tasks to available GPU infrastructure.
-- **[beta]** [hindsight-hermes](https://hindsight.vectorize.io/sdks/integrations/hermes) by [Vectorize](https://vectorize.io) - Long-term memory integration that replaces Hermes's built-in memory with three specialized tools: retain (store), recall (search), and reflect (reason over memories). Gives agents persistent memory across sessions via Hindsight memory banks.
+- **[beta]** [hindsight-hermes](https://hindsight.vectorize.io/sdks/integrations/hermes) by [Vectorize](https://vectorize.io) - State-of-the-art AI agent memory integration that replaces Hermes's built-in memory with persistent, cross-session memory banks powered by Hindsight.
 
 <br>
 


### PR DESCRIPTION
## Summary
- Adds [hindsight-hermes](https://hindsight.vectorize.io/sdks/integrations/hermes) by Vectorize to the **Integrations & Bridges** section
- Hindsight replaces Hermes's built-in memory with three specialized tools (retain, recall, reflect) for persistent cross-session memory via memory banks

## Test plan
- [ ] Verify the link resolves correctly
- [ ] Confirm entry formatting matches the rest of the list