### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) - Solana blockchain intelligence MCP server. Provides on-chain analytics and wallet data to Hermes via MCP.
 - **[experimental]** [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) - Adversarial multi-perspective council MCP server. Multiple AI viewpoints debate before the agent commits to a decision.
 - **[experimental]** [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) - NVIDIA capability registry and Spark-aware routing layer. Routes compute-heavy tasks to available GPU infrastructure.
+- **[production]** [Hindsight](https://hindsight.vectorize.io) by [Vectorize](https://github.com/vectorize-io) - State-of-the-art long-term memory for AI agents. Open-source (MIT), fully self-hostable. Registers retain, recall, and reflect tools via the [Hermes plugin](https://hindsight.vectorize.io/integrations) or MCP. Replaces the built-in memory with semantic, graph, and temporal retrieval.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) - Solana blockchain intelligence MCP server. Provides on-chain analytics and wallet data to Hermes via MCP.
 - **[experimental]** [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) - Adversarial multi-perspective council MCP server. Multiple AI viewpoints debate before the agent commits to a decision.
 - **[experimental]** [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) - NVIDIA capability registry and Spark-aware routing layer. Routes compute-heavy tasks to available GPU infrastructure.
-- **[production]** [Hindsight](https://hindsight.vectorize.io) by [Vectorize](https://github.com/vectorize-io) - State-of-the-art long-term memory for AI agents. Open-source (MIT), fully self-hostable. Registers retain, recall, and reflect tools via the [Hermes plugin](https://hindsight.vectorize.io/integrations) or MCP. Replaces the built-in memory with semantic, graph, and temporal retrieval.
+- **[production]** [Hindsight](https://github.com/vectorize-io/hindsight) by [Vectorize](https://github.com/vectorize-io) - Long-term memory for AI agents. Open-source (MIT), fully self-hostable. Registers retain, recall, and reflect tools via the [Hermes plugin](https://hindsight.vectorize.io/integrations) or MCP. Supports semantic, graph, and temporal retrieval. (See [#9](https://github.com/0xNyk/awesome-hermes-agent/issues/9))
 
 <br>
 


### PR DESCRIPTION
## Summary

- Adds [Hindsight](https://hindsight.vectorize.io) to the **Integrations & Bridges** section
- Hindsight is an open-source (MIT), fully self-hostable long-term memory system for AI agents by [Vectorize](https://github.com/vectorize-io)
- It has a dedicated [Hermes plugin](https://hindsight.vectorize.io/integrations) (`hindsight-hermes`) that registers retain, recall, and reflect tools, replacing the built-in memory with semantic, graph, and temporal retrieval
- GitHub: https://github.com/vectorize-io/hindsight

## Why it fits

Hindsight has a first-party Hermes integration — it installs as a plugin via `uv pip install hindsight-hermes` and registers three tools (`hindsight_retain`, `hindsight_recall`, `hindsight_reflect`) directly into Hermes's tool system. It also works via MCP. Production-grade, 10k+ GitHub stars, actively maintained.