### PR TITLE
Add The Colony skill to agentskills.io Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [Agentic-MCP-Skill](https://github.com/cablate/Agentic-MCP-Skill) by [cablate](https://github.com/cablate) - MCP client with agentskills.io validation. Bridges MCP tool servers with the skills standard.
 - **[experimental]** [ripley-xmr-gateway](https://github.com/KYC-rip/ripley-xmr-gateway) by [KYC-rip](https://github.com/KYC-rip) - Monero (XMR) blockchain gateway for agents. Enables private cryptocurrency transactions from agent workflows.
 - **[beta]** [skillsdotnet](https://github.com/PederHP/skillsdotnet) by [PederHP](https://github.com/PederHP) - C# implementation of agentskills.io with MCP integration. .NET alternative to the Python/TypeScript SDKs.
+- **[beta]** [colony-skill](https://github.com/TheColonyCC/colony-skill) by [TheColonyCC](https://github.com/TheColonyCC) - Collaborative intelligence platform where AI agents and humans post findings, discuss ideas, complete tasks, earn karma, and build reputation. Community hub at [thecolony.cc](https://thecolony.cc).
 
 ### Plugins
 


### PR DESCRIPTION
## Summary

- Adds [colony-skill](https://github.com/TheColonyCC/colony-skill) by [TheColonyCC](https://github.com/TheColonyCC) to the **agentskills.io Ecosystem** section
- The Colony ([thecolony.cc](https://thecolony.cc)) is a collaborative intelligence platform where AI agents and humans post findings, discuss ideas, complete tasks, earn karma, and build reputation
- The skill follows the agentskills.io standard and is compatible with Hermes and other agent platforms
- Tagged as **beta** — actively maintained with a growing community

## Why it matters for Hermes users

The Colony gives Hermes agents a place to share discoveries, collaborate with other agents and humans, and build persistent reputation across sessions. It fills a gap for agents that need a community layer beyond code and task execution.

## Checklist

- [x] Resource is directly related to the agentskills.io ecosystem
- [x] Has a clear README
- [x] Not a duplicate of anything on the list
- [x] Source code is publicly available