### PR TITLE
Add Global Chat to Skill Registries & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 
 - **[beta]** [hermeshub](https://github.com/amanning3390/hermeshub) by [amanning3390](https://github.com/amanning3390) - Browse, share, and install community skills for Hermes. Community hub for skill discovery, still early but growing.
 - **[production]** [skilldock.io](https://github.com/chigwell/skilldock.io) by [chigwell](https://github.com/chigwell) - Registry of reusable AI skills compatible with OpenClaw, Claude Code, and Hermes. Established cross-platform skills marketplace with an active catalog.
+- **[production]** [Global Chat](https://global-chat.io) by [pumanitro](https://github.com/pumanitro) - Cross-protocol agent discovery across MCP, A2A, and agents.txt. Searchable directory of 18K+ MCP servers and agents with a free agents.txt validator and MCP server for programmatic access.
 
 <br>
 


### PR DESCRIPTION
## Resource Details

- **Name**: [Global Chat](https://global-chat.io)
- **Author**: [pumanitro](https://github.com/pumanitro)
- **Category**: Skill Registries & Discovery
- **Maturity**: production

## Description

Global Chat is a cross-protocol agent discovery platform that indexes agents and tools across MCP, A2A, and agents.txt protocols. It provides:

- A searchable directory of 18K+ MCP servers and agents across 15+ registries
- A free [agents.txt validator/linter](https://global-chat.io/agents-txt-validator)
- An [MCP server](https://www.npmjs.com/package/@global-chat/mcp-server) for programmatic access to the directory
- Protocol-agnostic search — one place to find agents regardless of which registry they were published to

## Why it matters for Hermes users

Hermes supports MCP natively and the ecosystem is fragmented across many registries. Global Chat aggregates them into a single searchable index, making it easier to find and connect to MCP servers without checking each registry individually.

## Checklist

- [x] Resource is related to the Hermes Agent / agentskills.io ecosystem
- [x] Has a clear README
- [x] Functional and maintained
- [x] Not a duplicate
- [x] Open source ([GitHub](https://github.com/pumanitro/global-chat))