### PR TITLE
Add Exfer blockchain skill to agentskills.io Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [bmad-module-skill-forge](https://github.com/armelhbobdad/bmad-module-skill-forge) by [armelhbobdad](https://github.com/armelhbobdad) - Transforms repos and docs into agentskills.io-compliant skills. Input a codebase, output installable skills.
 - **[beta]** [Agentic-MCP-Skill](https://github.com/cablate/Agentic-MCP-Skill) by [cablate](https://github.com/cablate) - MCP client with agentskills.io validation. Bridges MCP tool servers with the skills standard.
 - **[experimental]** [ripley-xmr-gateway](https://github.com/KYC-rip/ripley-xmr-gateway) by [KYC-rip](https://github.com/KYC-rip) - Monero (XMR) blockchain gateway for agents. Enables private cryptocurrency transactions from agent workflows.
+- **[beta]** [exfer](https://github.com/ahuman-exfer/exfer) by [ahuman-exfer](https://github.com/ahuman-exfer) - Proof-of-work blockchain for autonomous machine-to-machine commerce. Agents can send payments, create HTLCs, mine blocks, and earn EXFER by solving tasks via a built-in [task server](http://82.221.100.201:8080/api/v1/tasks). [Skill reference](https://exfer.org/SKILL.html).
 - **[beta]** [skillsdotnet](https://github.com/PederHP/skillsdotnet) by [PederHP](https://github.com/PederHP) - C# implementation of agentskills.io with MCP integration. .NET alternative to the Python/TypeScript SDKs.
 
 ### Plugins


### PR DESCRIPTION
## What

Adds [Exfer](https://github.com/ahuman-exfer/exfer) to the **agentskills.io Ecosystem** section.

## Entry

```
- **[beta]** [exfer](https://github.com/ahuman-exfer/exfer) by [ahuman-exfer](https://github.com/ahuman-exfer) - Proof-of-work blockchain for autonomous machine-to-machine commerce. Agents can send payments, create HTLCs, mine blocks, and earn EXFER by solving tasks via a built-in task server. Skill reference.
```

## Why it belongs here

- **agentskills.io compliant**: SKILL.md follows the agentskills.io spec with proper frontmatter (name, description, license, metadata)
- **Agent-native**: designed for machine-to-machine commerce, not human users
- **Task server faucet**: agents can earn EXFER by solving tasks (math, crypto, on-chain queries) via HTLC claims — no mining required
- **Active network**: 550+ nodes, 180+ unique miners, 28 countries, running for 25+ days
- **Pre-built binaries**: Linux, macOS, Windows via GitHub Releases
- **One-command onboarding**: `exfer init` gets an agent from zero to running

## Placement

Added next to `ripley-xmr-gateway` (the other blockchain/crypto entry in the agentskills.io section).