### PR TITLE
Add Not Human Search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [hermes-agent-acp-skill](https://github.com/Rainhoole/hermes-agent-acp-skill) by [Rainhoole](https://github.com/Rainhoole) - Multi-agent delegation skill bridging Hermes, Codex, and Claude Code. Routes subtasks to the best-suited agent automatically.
 - **[experimental]** [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) - Solana blockchain intelligence MCP server. Provides on-chain analytics and wallet data to Hermes via MCP.
 - **[experimental]** [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) - Adversarial multi-perspective council MCP server. Multiple AI viewpoints debate before the agent commits to a decision.
+- **[production]** [Not Human Search](https://github.com/unitedideas/nothumansearch-mcp) by [unitedideas](https://github.com/unitedideas) - MCP server for discovering other MCP servers. Indexes 8,600+ agent-friendly sites with agentic scoring, category filters, and live JSON-RPC verification. Wire it into Hermes via MCP to let the agent find and evaluate new tools to integrate on its own. Live at [nothumansearch.ai](https://nothumansearch.ai).
 - **[experimental]** [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) - NVIDIA capability registry and Spark-aware routing layer. Routes compute-heavy tasks to available GPU infrastructure.
 
 <br>


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) to the Integrations & Bridges section — MCP servers that extend Hermes via MCP.

**What it is:** An MCP server that indexes 8,600+ agent-friendly sites (MCP servers, llms.txt, OpenAPI, ai-plugin.json) with an agentic score (0-100), category filters, tag search, and live JSON-RPC `verify_mcp` probe. Wire it into Hermes via MCP and the agent can discover and evaluate new tools to integrate on its own — natural fit for Hermes's self-improving loop.

**Tools exposed over MCP:** `search`, `get_site`, `list_categories`, `get_top_sites`, `verify_mcp`, and more (8 total).

**Status:** Production. Live at nothumansearch.ai, published to the official MCP registry as `ai.nothumansearch/search`, JSON-RPC endpoint at `https://nothumansearch.ai/mcp`.

Placed under Integrations & Bridges alongside the other MCP servers (`hermes-blockchain-oracle`, `hermes-council`) since it follows the same pattern — an MCP server Hermes can integrate with at runtime.