### PR TITLE
Add personal-api to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [hermes-incident-commander](https://github.com/Lethe044/hermes-incident-commander) by [Lethe044](https://github.com/Lethe044) - Autonomous SRE agent for production incident detection and self-healing. Monitors services, diagnoses failures, and applies fixes. Works well with Hermes's cron scheduling.
 - **[beta]** [hermes-dojo](https://github.com/Yonkoo11/hermes-dojo) by [Yonkoo11](https://github.com/Yonkoo11) - Self-improvement system that monitors agent performance, identifies weak skills, and iterates on them automatically.
 - **[experimental]** [hermes-skill-marketplace](https://github.com/Lethe044/hermes-skill-marketplace) by [Lethe044](https://github.com/Lethe044) - Agent that writes, tests, and publishes new skills autonomously. Automates the skill creation and distribution lifecycle.
+- **[experimental]** [personal-api](https://github.com/beiyuii/personal-api-skill) by [beiyuii](https://github.com/beiyuii) - Turn your Obsidian vault into an identity layer any AI agent can read in under 30 seconds
 
 
 ### agentskills.io Ecosystem


### PR DESCRIPTION
## What
Adds `personal-api` to the Community Skills list.

## Entry
```
- **[experimental]** [personal-api](https://github.com/beiyuii/personal-api-skill) by [beiyuii](https://github.com/beiyuii) - Turn your Obsidian vault into an identity layer any AI agent can read in under 30 seconds
```

## About the skill
`personal-api` turns an Obsidian vault into a portable identity layer. Any AI agent (Claude Code, Cursor, Codex, etc.) reads `ME.md` + `AGENT.md` in under 30 seconds to understand the user's background, principles, and collaboration preferences.
- Zero network calls, zero runtime dependencies
- Pure Markdown + bash
- Wikilink-based layered context (agents fetch depth on demand)

## Maturity rationale
Marked **experimental** honestly: the skill was just released and has no external users yet. Will submit a follow-up PR to promote to `beta` once it has been battle-tested in the community.

## Related
- Skill upstream: https://github.com/beiyuii/personal-api-skill
- HermesHub registration PR: https://github.com/amanning3390/hermeshub/pull/51

## Conformance checklist
- [x] Entry format matches existing Community Skills items
- [x] Maturity label uses defined vocabulary (`experimental`)
- [x] One-line description under 20 words
- [x] Only modifies README.md, single-line addition
