### PR TITLE
Add Agent Analytics Hermes plugin to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [hermes-plugin-chrome-profiles](https://github.com/anpicasso/hermes-plugin-chrome-profiles) by [anpicasso](https://github.com/anpicasso) - Switch browser tools between Chrome profiles via CDP. Useful for multi-account testing or browsing with different saved sessions.
 - **[experimental]** [hermes-cloudflare](https://github.com/raulvidis/hermes-cloudflare) by [raulvidis](https://github.com/raulvidis) - Cloudflare browser rendering plugin. Headless browsing through Cloudflare's infrastructure instead of local browser automation.
 - **[beta]** [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) by [42-evey](https://github.com/42-evey) - Claude Code plugin for bridging with Evey (hermes-agent). Lets Claude Code and Hermes share context and hand off tasks between each other.
+- **[beta]** [agent-analytics-hermes-plugin](https://github.com/Agent-Analytics/agent-analytics-hermes-plugin) by [Agent-Analytics](https://github.com/Agent-Analytics) - Native Signals dashboard tab for Hermes with read-only multi-project analytics, explicit timeframe, and theme-aware UI.
 
 ### Skill Registries & Discovery
 


### PR DESCRIPTION
## Summary
Adds Agent Analytics Hermes dashboard plugin to the Awesome Hermes Agent plugins section.
## Added entry
- https://github.com/Agent-Analytics/agent-analytics-hermes-plugin
- Native Signals dashboard tab for Hermes with read-only multi-project analytics, explicit timeframe, and theme-aware UI.
<img width="1489" height="1056" alt="agent-analytics-hermes-plugin" src="https://github.com/user-attachments/assets/c870c3e9-b409-4222-9935-5e14cca77200" />
