### PR TITLE
Add proxyclaw: residential proxy routing for all Hermes web tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [personal-api](https://github.com/beiyuii/personal-api-skill) by [beiyuii](https://github.com/beiyuii) - Turn your Obsidian vault into an identity layer any AI agent can read in under 30 seconds
 
 
+- **[beta]** [proxyclaw-hermes-skill](https://github.com/Iploop/proxyclaw-hermes-skill) by [IPLoop](https://proxyclaw.ai) - Residential proxy routing for all Hermes web tools. Routes `web_search`, `web_extract`, `web_crawl`, browser tools, and Scrapling through real device IPs in 100+ countries. Beats Cloudflare and datacenter IP blocks that stop VPS-hosted agents cold. One API key, free 500MB tier.
+
 ### agentskills.io Ecosystem
 
 > Skills built on the [agentskills.io](https://agentskills.io) open standard — compatible across Hermes and other agent platforms.


### PR DESCRIPTION
Adds [proxyclaw-hermes-skill](https://github.com/Iploop/proxyclaw-hermes-skill) to Community Skills.

**What it does:** Routes all Hermes web tools (`web_search`, `web_extract`, `web_crawl`, browser, Scrapling) through ProxyClaw residential proxies — real device IPs, 100+ countries.

**Why it's useful:** Most Hermes deployments run on VPS/cloud. Datacenter IPs get blocked by Cloudflare, LinkedIn, Amazon, Google, etc. This fixes it at the network level — no code changes to how the agent makes requests.

**Status:** beta — tested on Hermes Agent v0.10.0
**License:** MIT
**Free tier:** 500MB, no card required at https://proxyclaw.ai