### PR TITLE
Add Skills宝 registry entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [hermeshub](https://github.com/amanning3390/hermeshub) by [amanning3390](https://github.com/amanning3390) - Browse, share, and install community skills for Hermes. Community hub for skill discovery, still early but growing.
 - **[production]** [skilldock.io](https://github.com/chigwell/skilldock.io) by [chigwell](https://github.com/chigwell) - Registry of reusable AI skills compatible with OpenClaw, Claude Code, and Hermes. Established cross-platform skills marketplace with an active catalog.
 - **[production]** [Global Chat](https://global-chat.io) by [pumanitro](https://github.com/pumanitro) - Cross-protocol agent discovery across MCP, A2A, and agents.txt. Searchable directory of 18K+ MCP servers and agents with a free agents.txt validator and MCP server for programmatic access.
+- **[beta]** [Skills宝](https://skilery.com) - Chinese search and install registry for AI skills across Claude Code, OpenCode, and other agent tools.
 
 <br>
 


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a skills registry/discovery resource in the Skill Registries & Discovery section.

This keeps the reference aligned with the repo's existing discovery-oriented resources like hermeshub and skilldock.io.