### PR TITLE
Add loom-hermes-adapter to Multi-Agent & Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [gladiator](https://github.com/runtimenoteslabs/gladiator) by [runtimenoteslabs](https://github.com/runtimenoteslabs) - Two autonomous AI companies compete for GitHub stars. Hackathon project exploring autonomous agent competition dynamics.
 - **[beta]** [bigiron](https://github.com/supermodeltools/bigiron) by [supermodeltools](https://github.com/supermodeltools) - AI-native SDLC with Hermes and Supermodel code graph. Full software development lifecycle driven by coordinated agents.
 - **[beta]** [opencode-hermes-multiagent](https://github.com/1ilkhamov/opencode-hermes-multiagent) by [1ilkhamov](https://github.com/1ilkhamov) - 17 specialized agents for OpenCode AI. Each agent has a defined role and they communicate through structured interfaces.
+- **[experimental]** [loom-hermes-adapter](https://github.com/wanikua/loom/tree/main/integrations/hermes) by [wanikua](https://github.com/wanikua) - Run Hermes Agent as a federated specialist inside a [Loom](https://github.com/wanikua/loom) multi-agent hub. A TS Loom Manager DELEGATEs tasks to a remote Python `LoomSpecialist` whose `propose` callable spawns `hermes chat -q` and feeds stdout back as a structured proposal that a TS Critic evaluates. Cross-language federation (TS Manager + Python Hermes worker on the same Bus), event-sourced timeline = postmortem, approval-gated remediation. Mock mode for offline demos. Uses Hermes' standard non-interactive CLI flags (no fork required).
 
 <br>
 


### PR DESCRIPTION
Adds [loom-hermes-adapter](https://github.com/wanikua/loom/tree/main/integrations/hermes) — Hermes Agent as a federated specialist in a Loom multi-agent hub.

### What it is

A small Python adapter (in the [Loom](https://github.com/wanikua/loom) repo, MIT-licensed) that lets a TS Loom Manager DELEGATE work to a Python `LoomSpecialist` whose `propose` callable spawns `hermes chat -q "<query>" -Q --yolo` and returns the stdout as a structured proposal. The Loom Critic evaluates the result and CRITIQUE/COMMIT cycles work exactly like any other Specialist.

```
   Loom Manager (TS)  ──DELEGATE──▶  LoomSpecialist (Python)
                                          │
                                          ▼
                              hermes chat -q "<goal>" -Q --yolo
                                          │
   Loom Critic (TS)  ◀───PROPOSE──────────┘
```

### Why a Hermes adapter

Hermes already has its own multi-agent orchestration via `kanban` skills, so this isn't "teach Hermes multi-agent." The differentiation is what Loom adds **alongside** Hermes:

- **Cross-language federation** — TS Manager + Python Hermes worker on the same Bus (byte-for-byte protocol-compatible)
- **EventStore replay = postmortem** — every DELEGATE/PROPOSE/CRITIQUE/COMMIT durable; `forkFromSnapshot` lets you branch from any point
- **Approval gates as first-class events** — `approval.requested` lands in the log, run pauses, resolves on a human's `/loom approve <id>`
- **Bus / Transport abstraction** — same Hermes specialist participates in an in-process hub, Discord war-room, Slack channel, or browser chat panel without code changes

### Usage

```python
from loom import LoomClient, LoomSpecialist
from loom_hermes import HermesProposer

proposer = HermesProposer(model="anthropic/claude-sonnet-4")
async with LoomClient(ws_url="ws://127.0.0.1:8432/im", room="warroom",
                     agent_id="hermes-1") as client:
    await LoomSpecialist(client, propose=proposer).run_forever()
```

Mock mode (`HermesProposer(mock=True)`) lights up the entire DELEGATE/PROPOSE/CRITIQUE/COMMIT loop without a Hermes install — useful for CI smoke tests.

### Notes

- Uses the documented non-interactive CLI flags only (no fork of Hermes required); same approach as `hermes-paperclip-adapter`
- 12 pytest cases covering mock/binary-resolution/argv/success/timeout/non-zero-exit
- End-to-end smoke verified: HUMAN → harness ack → Manager DELEGATE → Python HermesProposer → PROPOSE → Critic COMMIT → run completed in 30ms (18 events persisted)
- Tagged `[experimental]` since it just shipped (PR #7 in the Loom repo on 2026-05-10)