### PR TITLE
Add MisakaNet to Multi-Agent & Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [gladiator](https://github.com/runtimenoteslabs/gladiator) by [runtimenoteslabs](https://github.com/runtimenoteslabs) - Two autonomous AI companies compete for GitHub stars. Hackathon project exploring autonomous agent competition dynamics.
 - **[beta]** [bigiron](https://github.com/supermodeltools/bigiron) by [supermodeltools](https://github.com/supermodeltools) - AI-native SDLC with Hermes and Supermodel code graph. Full software development lifecycle driven by coordinated agents.
 - **[beta]** [opencode-hermes-multiagent](https://github.com/1ilkhamov/opencode-hermes-multiagent) by [1ilkhamov](https://github.com/1ilkhamov) - 17 specialized agents for OpenCode AI. Each agent has a defined role and they communicate through structured interfaces.
+- **[beta]** [MisakaNet](https://github.com/Ikalus1988/MisakaNet) by [Ikalus1988](https://github.com/Ikalus1988) - Git-based distributed swarm memory for Hermes and other AI agents. When one agent solves a problem, every node on the network learns from it via shared markdown lessons synced through GitHub Issues. 104+ lessons across 7 domains, 21+ registered nodes (Hermes, Claude, Codex, OpenClaw, OpenCode). Zero infrastructure beyond GitHub.
 
 <br>
 


### PR DESCRIPTION
## Summary

Adds [MisakaNet](https://github.com/Ikalus1988/MisakaNet) to the **Multi-Agent & Swarms** section.

## Why it fits here

MisakaNet is specifically designed for the Hermes ecosystem — it's a **distributed swarm memory** that lets Hermes agents share hard-won debugging knowledge across nodes:

- **21+ registered nodes** including Hermes, Claude, Codex, OpenClaw, OpenCode
- **104+ shared lessons** across 7 domains (devops, feishu, rag, claude, hub, network, fanuc)
- **GitHub Issues as message bus** — zero infrastructure, built-in auth
- **Git for sync** — offline-first, conflict-resilient, every node has full history
- **Markdown lessons** — human-readable, git-diffable, searchable

The key insight: when one Hermes agent spends 3 hours debugging a ChromaDB NTFS issue, every other node on the network can find the fix in seconds. Knowledge compounds across the fleet.

## Links

- [GitHub](https://github.com/Ikalus1988/MisakaNet)
- [Wiki](https://github.com/Ikalus1988/MisakaNet/wiki)
- License: Apache 2.0