### PR TITLE
Add blacktea to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[experimental]** [personal-api](https://github.com/beiyuii/personal-api-skill) by [beiyuii](https://github.com/beiyuii) - Turn your Obsidian vault into an identity layer any AI agent can read in under 30 seconds
 - **[beta]** [hermes-nextcloud](https://github.com/adnw-vinc/hermes-nextcloud) by [adnw-vinc](https://github.com/adnw-vinc) - Self-hosted Nextcloud bridge — manage files (WebDAV), notes (Nextcloud Notes API), calendar/tasks (CalDAV), and contacts (CardDAV) from Hermes. App Password auth, configurable timezone, guided setup. Fills the self-hosted-cloud gap for Hermes users running their own infrastructure.
 - **[beta]** [oh-my-hermes](https://github.com/witt3rd/oh-my-hermes) by [witt3rd](https://github.com/witt3rd) - Multi-agent orchestration skills for Hermes inspired by `oh-my-claudecode` and rebuilt on Hermes primitives. Suite covers deep-research, deep-interview, `ralplan` (Planner → Architect → Critic consensus), `ralph` (verified execute → verify → iterate), `triage`, and `autopilot`, plus driver skills encoding the dispatcher's playbook. Composes end-to-end: research → interview → consensus plan → verified execution.
-
+- **[beta]** [blacktea](https://github.com/nmrtn/blacktea) by [nmrtn](https://github.com/nmrtn) - Spending controls for agents that pay online via x402. Holds over-limit payments for human approval in the chat, enforces a JSON policy, and audits every spend. Ships as an MCP server (pay, approve_payment, reject_payment, audit_query) plus an SDK and CLI.
 
 ### agentskills.io Ecosystem
 


### PR DESCRIPTION
Adds **blacktea** under Skills & Plugins → Community Skills.

blacktea is an open-source spending-controls layer for agents that pay online via x402. It runs as an MCP server (tools: `pay`, `approve_payment`, `reject_payment`, `audit_query`) and also ships an SDK and CLI. When a payment is over the user's auto-approve limit, the agent asks the human in the chat and only settles after they confirm; below the limit it pays, over the hard limit it rejects, and every payment is audited.

It ships an agentskills.io-compatible SKILL.md and was tested live on Hermes Agent (real on-chain settlement on Base Sepolia after in-chat approval).

- Repo: https://github.com/nmrtn/blacktea (MIT, clear README, actively maintained)
- npm: https://www.npmjs.com/package/@nmrtn/blacktea-mcp

Checked for duplicates: blacktea is not currently listed.