### PR TITLE
feat: add TWZRD Agent Intel — Solana agent trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [mercury](https://github.com/hxsteric/mercury) by [hxsteric](https://github.com/hxsteric) - Multi-chain blockchain cash flow analyzer with WebGL dashboard. On-chain forensics and flow visualization.
 - **[experimental]** [hermes-research-agent](https://github.com/Aum08Desai/hermes-research-agent) by [Aum08Desai](https://github.com/Aum08Desai) - Autonomous LLM research agent. Handles literature review, hypothesis generation, and experiment design end-to-end.
 
+- **[production]** [TWZRD Agent Intel](https://intel.twzrd.xyz) — Trust scoring MCP for autonomous Solana agents. Call `score_agent(wallet)` and `preflight_check(wallet)` free; `get_trust_receipt(wallet)` verifies agent identity before high-value operations via x402 micropayment. Useful for verifying Hermes agent wallet identity in multi-agent or enterprise workflows. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`.
+
 <br>
 
 ## Forks & Derivatives


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — a production-grade trust scoring MCP server for autonomous Solana agents.

Added to the **Domain Applications** section as a production-ready blockchain/agent identity tool.

## Why it fits here

Hermes Agent supports MCP integration natively. TWZRD Agent Intel provides trust scoring for autonomous AI agents operating on Solana — directly useful for Hermes deployments handling multi-agent coordination, x402 micropayments, or any workflow where verifying another agent's wallet identity matters before taking high-value actions.

## The tool

- **score_agent(wallet)** — returns trust score (0–1), reputation signals, and behavioral flags. Free.
- **preflight_check(wallet)** — structured go/no-go verdict before agent interactions. Free.
- **get_trust_receipt(wallet)** — cryptographically signed trust receipt for audit trails. Paid via x402 micropayment (~$0.001 USDC).

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Streamable-HTTP transport, no API key required for free tools.