### PR TITLE
feat: add CreatorSkills marketplace to Skill Registries & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [hermeshub](https://github.com/amanning3390/hermeshub) by [amanning3390](https://github.com/amanning3390) - Browse, share, and install community skills for Hermes. Community hub for skill discovery, still early but growing.
 - **[production]** [skilldock.io](https://github.com/chigwell/skilldock.io) by [chigwell](https://github.com/chigwell) - Registry of reusable AI skills compatible with OpenClaw, Claude Code, and Hermes. Established cross-platform skills marketplace with an active catalog.
 - **[production]** [Global Chat](https://global-chat.io) by [pumanitro](https://github.com/pumanitro) - Cross-protocol agent discovery across MCP, A2A, and agents.txt. Searchable directory of 18K+ MCP servers and agents with a free agents.txt validator and MCP server for programmatic access.
+- **[production]** [CreatorSkills](https://creatorskills.co) by [CreatorSkills](https://github.com/calebvbi) - Curated marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Uses the open SKILL.md format; skills install into Hermes, Claude Code, ChatGPT, and 20+ compatible platforms.
 
 <br>
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Skill Registries & Discovery** section.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills for content creators, including skills for YouTube scripting, sponsorship analysis, content repurposing, and audience growth.

**Why it fits here:**
- Uses the open SKILL.md / [agentskills.io](https://agentskills.io) standard — satisfying the contribution requirement
- Skills are compatible with Hermes Agent, Claude Code, ChatGPT, and 20+ AI platforms
- Functions as a skill registry/discovery platform (the exact purpose of this section)
- Active marketplace with production-quality, domain-specific skills

This is a complementary addition to the existing registries (hermeshub, skilldock.io, Global Chat) with a distinct focus on content creator workflows.