### PR TITLE
add: TypeUI for Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[production]** [skilldock.io](https://github.com/chigwell/skilldock.io) by [chigwell](https://github.com/chigwell) - Registry of reusable AI skills compatible with OpenClaw, Claude Code, and Hermes. Established cross-platform skills marketplace with an active catalog.
 - **[production]** [Global Chat](https://global-chat.io) by [pumanitro](https://github.com/pumanitro) - Cross-protocol agent discovery across MCP, A2A, and agents.txt. Searchable directory of 18K+ MCP servers and agents with a free agents.txt validator and MCP server for programmatic access.
 - **[production]** [CreatorSkills](https://creatorskills.co) by [CreatorSkills](https://github.com/calebvbi) - Curated marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Uses the open SKILL.md format; skills install into Hermes, Claude Code, ChatGPT, and 20+ compatible platforms.
+- **[production]** [TypeUI for Hermes](https://www.typeui.sh/docs/guides/hermes) by [Bergside](https://github.com/bergside/typeui) - Curated list of design skills to give your Hermes agent better context when building user interfaces.
 
 <br>
 


### PR DESCRIPTION
Hey @0xNyk,

I added TypeUI for Hermes (https://www.typeui.sh/docs/guides/hermes) to the list.

It's basically a registry of design skills to build better UI.

Thanks man!