### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 ### Plugins
 
 - **[beta]** [plur](https://github.com/plur-ai/plur) by [plur-ai](https://github.com/plur-ai) - Shared memory layer for AI agents with open engram format (YAML). Useful for persistent learning patterns in Hermes workflows.
+- **[production]** [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) by [Xquik-dev](https://github.com/Xquik-dev) - X/Twitter plugin for Hermes Agent with search, profile/timeline reads, and optional posting/follow actions. Read tools require `XQUIK_API_KEY`; actions require explicit `HERMES_TWEET_ENABLE_ACTIONS=true`.
 - **[experimental]** [hermes-payguard](https://github.com/nativ3ai/hermes-payguard) by [nativ3ai](https://github.com/nativ3ai) - Safe USDC and x402 payment plugin. Lets Hermes send and receive payments with configurable spending limits and approval flows.
 - **[beta]** [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) by [robbyczgw-cla](https://github.com/robbyczgw-cla) - Multi-provider web search with intelligent routing across Serper, Tavily, Exa, and more. Replaces the built-in search with better result quality and source diversity.
 - **[beta]** [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) - Professional-grade weather plugin with NWS model imagery, NEXRAD radar, and meteorological calculations.


### PR DESCRIPTION
## Summary
- Add Hermes Tweet to the Hermes plugin list.
- Describe its X/Twitter read tools and explicit action gate.

## Validation
- Checked existing PRs for Hermes Tweet, Xquik, TweetClaw, and X/Twitter duplicates in this repo: none found.
- Verified Xquik-dev/hermes-tweet is public and not archived.
- Reviewed repository license file: CC BY 4.0.