### PR TITLE
ci: lychee link checker (weekly + on-PR)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,39 @@
+name: Check links
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+  schedule:
+    # Weekly, Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --accept 200..=204,403,429
+            --max-concurrency 8
+            README.md
+          fail: ${{ github.event_name == 'pull_request' }}
+
+      - name: Open issue on scheduled failure
+        if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Link check: dead links found"
+          content-filepath: ./lychee/out.md
+          labels: bug


### PR DESCRIPTION
Follow-up to #204 — this is the workflow file that couldn't ride in that PR (token lacked `workflow` scope at the time).

- **On PR**: runs lychee against README.md when it changes; fails the check on dead links
- **Weekly** (Mondays 06:00 UTC): full sweep; opens an issue with the report if dead links are found
- Accepts 403/429 since several listed sites (typeui.sh, global-chat.io, etc.) rate-limit or block bots

With ~200 external links and this round's triage having caught multiple dead/moved URLs, this keeps the list honest between triage batches.