### PR TITLE
Add ditto to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Once you're comfortable, explore the full list below. Every resource is tagged w
 - **[beta]** [hurmoz](https://github.com/Moshe-ship/hurmoz) by [Moshe-ship](https://github.com/Moshe-ship) - Arabic-first skills pack — 63 skills across Islamic tools (prayer times, zakat, Quran), dialect-aware NLP, content, and travel. Install: `hermes skills tap add Moshe-ship/hurmoz`.
 - **[experimental]** [humanizer-ru](https://github.com/ilyautov/humanizer-ru) by [ilyautov](https://github.com/ilyautov) - Removes AI-writing tells from Russian text (bureaucratese, calques, ChatGPT/Claude fingerprints). 52 patterns, deterministic offline scanner. SKILL.md-compatible. MIT.
 - **[beta]** [skill-packs](https://github.com/shunfeng8421/skill-packs) by [shunfeng8421](https://github.com/shunfeng8421) - Premium deployable skill packs for crypto monitoring — cross-exchange arb scanner, DeFi security scanner, and cross-chain tracker. Self-adaptive thresholds, zero paid API dependencies, runs on a $5 VPS.
+- **[beta]** [ditto](https://github.com/ohad6k/ditto) by [ohad6k](https://github.com/ohad6k) - Mines your historical Claude Code / Codex / Copilot session logs into a personal profile skill Hermes loads natively. What your work already proved about you (what "done" means, what you reject, how you debug), available on day one instead of weeks of USER.md warm-up. Zero-dependency single-file Python, MIT.
 
 ### agentskills.io Ecosystem
 


### PR DESCRIPTION
ditto mines local coding-agent history (Claude Code, Codex, Copilot CLI) into a profile skill of how you actually work. I built it from my own 9 months of history, 1,656 sessions and about 3M tokens of just my messages.

Verified against a real Hermes 0.18.2 install before opening this: the profile skill drops into `<hermes-home>/skills/` and shows enabled in `hermes skills list`, no format changes needed. The repo has a Hermes setup guide at [docs/OPENCLAW_HERMES.md](https://github.com/ohad6k/ditto/blob/main/docs/OPENCLAW_HERMES.md).

Placed it in Community Skills since it loads as a standard skill. Happy to move it if you'd rather have it under agentskills.io Ecosystem.