### PR TITLE
Add hermes-tui-distraction-free to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ pruning, use the [Hermes Agent session management guide](https://www.nyk.dev/blo
 - **[production]** [DashClaw](https://github.com/ucsandman/DashClaw) by [ucsandman](https://github.com/ucsandman) - Approval and policy layer for agents: intercepts risky actions before they run and blocks or escalates them by rule. MIT.
 - **[beta]** [cronwatch](https://github.com/nicokickcpython/cronwatch) by [nicokickcpython](https://github.com/nicokickcpython) - Cron health hook that alerts on any scheduled job failure, without standing up a second cron to watch the first.
 - **[experimental]** [hermes-gondola-provider](https://github.com/Gondola-Market/hermes-gondola-provider) by [Gondola Market](https://github.com/Gondola-Market) - Gondola as a native model provider: a USDC-settled model marketplace wired in through the provider interface.
-- **[stable]** [hermes-no-tui-bloat](https://github.com/vadim-a-yegorov/hermes-no-tui-bloat) by [vadim-a-yegorov](https://github.com/vadim-a-yegorov) - Strips the kaomoji spinner and terminal pet from the Hermes TUI. The terminal is for work.
+- **[stable]** [hermes-tui-distraction-free](https://github.com/vadim-a-yegorov/hermes-tui-distraction-free) by [Vadym Yehorov](https://github.com/vadim-a-yegorov) - Strips the kaomoji spinner and terminal pet from the Hermes TUI, keeps pet in GUI.
 
 ### Skill Registries & Discovery
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   ·
   <a href="assets/BRAND.md">Brand kit</a>
 </p>
-
 # Awesome Hermes Agent
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
@@ -266,6 +265,7 @@ pruning, use the [Hermes Agent session management guide](https://www.nyk.dev/blo
 - **[production]** [DashClaw](https://github.com/ucsandman/DashClaw) by [ucsandman](https://github.com/ucsandman) - Approval and policy layer for agents: intercepts risky actions before they run and blocks or escalates them by rule. MIT.
 - **[beta]** [cronwatch](https://github.com/nicokickcpython/cronwatch) by [nicokickcpython](https://github.com/nicokickcpython) - Cron health hook that alerts on any scheduled job failure, without standing up a second cron to watch the first.
 - **[experimental]** [hermes-gondola-provider](https://github.com/Gondola-Market/hermes-gondola-provider) by [Gondola Market](https://github.com/Gondola-Market) - Gondola as a native model provider: a USDC-settled model marketplace wired in through the provider interface.
+- **[stable]** [hermes-no-tui-bloat](https://github.com/vadim-a-yegorov/hermes-no-tui-bloat) by [vadim-a-yegorov](https://github.com/vadim-a-yegorov) - Strips the kaomoji spinner and terminal pet from the Hermes TUI. The terminal is for work.
 
 ### Skill Registries & Discovery
 


### PR DESCRIPTION
## What does this PR change?

Adds **hermes-tui-distraction-free** to the Plugins section.

I am the author of this plugin ([@vadim-a-yegorov](https://github.com/vadim-a-yegorov)).

**hermes-tui-distraction-free** strips the kaomoji spinner (`( . .) musing...`) and the terminal pet from the Hermes TUI via two env vars:
- `NO_TUI_BLOAT=1` — replaces the kaomoji spinner with a plain "Working..." message
- `NO_TUI_PET=1` — removes the terminal pet

Useful for anyone who wants a cleaner, distraction-free terminal when using Hermes Agent, but still keep their pet alive in a GUI.

## Checklist

- [ ] This is NOT a new resource addition (those go through the [issue form](https://github.com/0xNyk/awesome-hermes-agent/issues/new?template=resource-submission.yml))
- [x] Links verified working
- [x] Description stays neutral — no pricing or promotional copy