### PR TITLE
Add price-digest to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pruning, use the [Hermes Agent session management guide](https://www.nyk.dev/blo
 
 ### Community Skills
 
+- **[beta]** [price-digest](https://github.com/salch-cred/hermes-price-digest) by [salch-cred](https://github.com/salch-cred) - Crypto price watchlist with a daily digest blueprint. Fetches spot prices and 24h change from CoinGecko's public API into a compact Markdown report — no API key, stdlib only.
 - **[beta]** [hermes-plugins](https://github.com/42-evey/hermes-plugins) by [42-evey](https://github.com/42-evey) - Plugin suite: Discord voice bridge with Gemini Live, WhatsApp bridge, goal management, inter-agent bridge, model selection, and cost control. Maintained by a frequent Hermes core contributor.
 - **[beta]** [hermes-skill-factory](https://github.com/Romanescu11/hermes-skill-factory) by [Romanescu11](https://github.com/Romanescu11) - Meta-skill that auto-generates reusable skills from your workflows. Point it at a task you repeat and it creates a skill for it.
 - **[beta]** [litprog-skill](https://github.com/tlehman/litprog-skill) by [tlehman](https://github.com/tlehman) - Literate programming skill that works across Claude Code, OpenCode, and Hermes. Weaves code and prose into documented, executable notebooks.


### PR DESCRIPTION
Adds [price-digest](https://github.com/salch-cred/hermes-price-digest) to Community Skills.

Crypto price watchlist + scheduled digest skill for Hermes Agent:

- Fetches spot prices and 24h change from CoinGecko's public API — no API key, stdlib only
- Renders a compact Markdown report; `--json` mode for scripting
- Ships as a **blueprint**: after install, `/suggestions` offers a daily 08:00 digest cron
- Watchlist and quote currency configurable via `skills.config.pricedigest.*`
- Offline test suite (`pytest`, no network), MIT licensed
