### PR TITLE
Add stipple-agent-skills to Detection & Media Forensics

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ pruning, use the [Hermes Agent session management guide](https://www.nyk.dev/blo
 > Skills for verifying whether incoming media is real or AI-generated — essential for agents that ingest user-submitted audio, images, video, or text.
 
 - **[beta]** [resemble-ai/detect-skill](https://github.com/resemble-ai/detect-skill) by [resemble-ai](https://github.com/resemble-ai) - Deepfake detection and media safety for agents. Detects AI-generated audio, images, video, and text; traces audio source (ElevenLabs, Resemble, etc.); applies invisible watermarks for provenance tracking; verifies speaker identity (Beta). Powered by [Resemble AI](https://resemble.ai). Core principle: never declare media real or fake without a completed detection result.
+- [Sketchjar/stipple-agent-skills](https://github.com/Sketchjar/stipple-agent-skills) by [Sketchjar](https://github.com/Sketchjar) - Document trust verification: forensic document authenticity (tamper risk bands + per-signal evidence on PDFs/images), AI-written-text detection with linguistic tells, citation verification, grounded extraction with abstention, identity checks, and adverse-media screening. Free anonymous tier. Same principle as Resemble: never declare a document genuine without a completed verification result.
 
 <br>
 


### PR DESCRIPTION
## What

Adds [Sketchjar/stipple-agent-skills](https://github.com/Sketchjar/stipple-agent-skills) to the **Detection & Media Forensics** section.

Document trust verification: forensic document authenticity (tamper risk bands + per-signal evidence on PDFs/images), AI-written-text detection, citation verification, grounded extraction, identity checks, and adverse-media screening. Free anonymous tier, no signup.

## Why this section

The section description says: 'Skills for verifying whether incoming media is real or AI-generated — essential for agents that ingest user-submitted audio, images, video, or text.' Stipple covers the **document** side of that: forensic tamper detection on PDFs/images and AI-written-prose detection on text. Same principle as Resemble AI's entry: never declare a document genuine without a completed verification result.

## Format

Follows the section's existing entry format: repo link, author attribution, one-paragraph description with core principle.